### PR TITLE
Fix potential StringIndexOutOfBoundsException when parsing authentication headers

### DIFF
--- a/src/main/java/org/codelibs/spnego/SpnegoProvider.java
+++ b/src/main/java/org/codelibs/spnego/SpnegoProvider.java
@@ -215,11 +215,13 @@ public final class SpnegoProvider {
             return null;
             
         } else if (header.startsWith(Constants.NEGOTIATE_HEADER)) {
-            final String token = header.substring(Constants.NEGOTIATE_HEADER.length() + 1);
+            final int prefixLength = Constants.NEGOTIATE_HEADER.length() + 1;
+            final String token = header.length() > prefixLength ? header.substring(prefixLength) : "";
             return new SpnegoAuthScheme(Constants.NEGOTIATE_HEADER, token);
             
         } else if (header.startsWith(Constants.BASIC_HEADER)) {
-            final String token = header.substring(Constants.BASIC_HEADER.length() + 1);
+            final int prefixLength = Constants.BASIC_HEADER.length() + 1;
+            final String token = header.length() > prefixLength ? header.substring(prefixLength) : "";
             return new SpnegoAuthScheme(Constants.BASIC_HEADER, token);
             
         } else {


### PR DESCRIPTION
This update enhances the robustness of SpnegoProvider by adding a length check before extracting authentication tokens from HTTP headers. Specifically:

- For both NEGOTIATE and BASIC authentication headers, the code now verifies that the header length exceeds the prefix length before calling substring.
- If the header only contains the prefix without a token, an empty string is used instead of attempting substring extraction.

These changes prevent potential StringIndexOutOfBoundsException errors when processing malformed or incomplete headers.