### PR TITLE
chore(build): update Maven plugins/deps and gate GPG signing on release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.14.0</version>
+				<version>3.15.0</version>
 				<configuration>
 					<release>11</release>
 					<encoding>UTF-8</encoding>
@@ -49,7 +49,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.11.2</version>
+				<version>3.12.0</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 					<docencoding>UTF-8</docencoding>
@@ -58,7 +58,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.4.2</version>
+				<version>3.5.0</version>
 				<configuration>
 					<archive>
 						<manifestEntries>
@@ -69,7 +69,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.5.0</version>
+				<version>3.5.5</version>
 				<configuration>
 					<includes>
 						<include>**/*Test.java</include>
@@ -84,7 +84,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.13</version>
+				<version>0.8.14</version>
 				<executions>
 					<execution>
 						<goals>
@@ -101,23 +101,9 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.2.7</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.10.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>central</publishingServerId>
@@ -125,11 +111,37 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>3.2.8</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<bestPractices>true</bestPractices>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	<dependencies>
 		<dependency>
 			<groupId>com.sun.xml.ws</groupId>
 			<artifactId>jaxws-rt</artifactId>
-			<version>4.0.2</version>
+			<version>4.0.4</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -147,13 +159,13 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>5.7.0</version>
+			<version>5.23.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-junit-jupiter</artifactId>
-			<version>5.7.0</version>
+			<version>5.23.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
## Summary
Routine maintenance bump of Maven build plugins and test dependencies, plus a small build-config change so GPG signing is only required for release builds.

## Changes Made
- Plugin bumps:
  - `maven-compiler-plugin` 3.14.0 → 3.15.0
  - `maven-javadoc-plugin` 3.11.2 → 3.12.0
  - `maven-jar-plugin` 3.4.2 → 3.5.0
  - `maven-surefire-plugin` 3.5.0 → 3.5.5
  - `jacoco-maven-plugin` 0.8.13 → 0.8.14
  - `central-publishing-maven-plugin` 0.7.0 → 0.10.0
- Dependency bumps:
  - `jaxws-rt` 4.0.2 → 4.0.4 (provided)
  - `mockito-core` / `mockito-junit-jupiter` 5.7.0 → 5.23.0 (test)
- Move `maven-gpg-plugin` (3.2.7 → 3.2.8) out of the default build into a new `release` profile, with `<bestPractices>true</bestPractices>` enabled. Non-release builds (`mvn package`, `mvn verify`, CI) no longer fail when no GPG key is configured; release builds opt in via `-Prelease`.

## Testing
- `mvn package` (and `mvn test`) should run without GPG keys present.
- For releases, run with `-Prelease` so `maven-gpg-plugin` re-binds to the `verify` phase.

## Breaking Changes
- Anyone currently relying on artifacts being GPG-signed during a plain `mvn verify` / `mvn install` must now pass `-Prelease`. The `CLAUDE.md` note that says "GPG signing is required for release builds" is still accurate, but it is now profile-gated rather than always-on.

## Additional Notes
- Mockito jumps several minor versions (5.7 → 5.23). Worth a quick eye on the test run in CI in case of behavioral changes.
- Update to `central-publishing-maven-plugin` 0.10.0 — please confirm Sonatype Central credentials/config in CI still work as expected on the next release.