### PR TITLE
chore(ci): update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'adopt'


### PR DESCRIPTION
## Summary

Bump outdated GitHub Actions to their current major versions to keep CI on supported runners and Node.js runtimes.

### `.github/workflows/maven.yml`
- `actions/checkout`: v2 -> v4
- `actions/setup-java`: v2 -> v4

### `.github/workflows/codeql-analysis.yml`
- `actions/checkout`: v2 -> v4 (all occurrences)
- `github/codeql-action/init`: v1 -> v3
- `github/codeql-action/autobuild`: v1 -> v3
- `github/codeql-action/analyze`: v1 -> v3

## Test plan

- [ ] `Java CI with Maven` workflow runs and passes on this PR
- [ ] `CodeQL` workflow runs and passes on this PR
- [ ] No deprecation warnings related to Node.js 12/16 in workflow logs