### PR TITLE
docs: improve Javadoc comments across core classes

### DIFF
--- a/src/main/java/org/codelibs/spnego/Base64.java
+++ b/src/main/java/org/codelibs/spnego/Base64.java
@@ -18,6 +18,9 @@
 
 package org.codelibs.spnego;
 
+/**
+ * Encodes and decodes data to and from Base64 notation.
+ */
 public final class Base64 {
 
     private static final String ALPHABET =

--- a/src/main/java/org/codelibs/spnego/SpnegoAuthenticator.java
+++ b/src/main/java/org/codelibs/spnego/SpnegoAuthenticator.java
@@ -131,11 +131,11 @@ public final class SpnegoAuthenticator {
      * Create an authenticator for SPNEGO and/or BASIC authentication.
      * 
      * @param config servlet filter initialization parameters
-     * @throws LoginException 
-     * @throws GSSException 
-     * @throws PrivilegedActionException 
+     * @throws LoginException if the server fails to login
+     * @throws GSSException if a GSS-API error occurs
+     * @throws PrivilegedActionException if a privileged action fails
      */
-    public SpnegoAuthenticator(final SpnegoFilterConfig config) 
+    public SpnegoAuthenticator(final SpnegoFilterConfig config)
         throws LoginException, GSSException, PrivilegedActionException {
 
         LOGGER.fine(() -> "config=" + config);
@@ -193,12 +193,12 @@ public final class SpnegoAuthenticator {
      * </code>
      * </p>
      * 
-     * @param config
-     * @throws LoginException
-     * @throws GSSException
-     * @throws PrivilegedActionException
-     * @throws FileNotFoundException
-     * @throws URISyntaxException
+     * @param config map of configuration parameters
+     * @throws LoginException if the server fails to login
+     * @throws GSSException if a GSS-API error occurs
+     * @throws PrivilegedActionException if a privileged action fails
+     * @throws FileNotFoundException if a referenced file cannot be found
+     * @throws URISyntaxException if a configured URI is malformed
      */
     public SpnegoAuthenticator(final Map<String, String> config) 
         throws LoginException, GSSException, PrivilegedActionException
@@ -238,9 +238,9 @@ public final class SpnegoAuthenticator {
      * 
      * @param loginModuleName module named defined in login.conf
      * @param config servlet filter initialization parameters
-     * @throws LoginException 
-     * @throws GSSException 
-     * @throws PrivilegedActionException 
+     * @throws LoginException if the server fails to login
+     * @throws GSSException if a GSS-API error occurs
+     * @throws PrivilegedActionException if a privileged action fails
      */
     public SpnegoAuthenticator(final String loginModuleName
         , final SpnegoFilterConfig config) throws LoginException
@@ -293,8 +293,8 @@ public final class SpnegoAuthenticator {
      * @param resp servlet response
      * 
      * @return null if auth not complete else SpnegoPrincipal of client
-     * @throws GSSException 
-     * @throws IOException 
+     * @throws GSSException if a GSS-API error occurs
+     * @throws IOException if an I/O error occurs
      */
     public SpnegoPrincipal authenticate(final HttpServletRequest req
         , final SpnegoHttpServletResponse resp) throws GSSException
@@ -549,6 +549,11 @@ public final class SpnegoAuthenticator {
         return new SpnegoPrincipal(principal, KerberosPrincipal.KRB_NT_PRINCIPAL, delegCred);
     }
     
+    /**
+     * Returns the realm of the server principal used for pre-authentication.
+     *
+     * @return the server's Kerberos realm
+     */
     public String getServerRealm() {
         return this.serverPrincipal.getRealm();
     }

--- a/src/main/java/org/codelibs/spnego/SpnegoHttpFilter.java
+++ b/src/main/java/org/codelibs/spnego/SpnegoHttpFilter.java
@@ -183,6 +183,13 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class SpnegoHttpFilter implements Filter {
 
+    /**
+     * Creates a new SPNEGO HTTP filter.
+     */
+    public SpnegoHttpFilter() {
+        super();
+    }
+
     private static final Logger LOGGER = Logger.getLogger(Constants.LOGGER_NAME);
 
     /** Object for performing Basic and SPNEGO authentication. */
@@ -305,6 +312,20 @@ public class SpnegoHttpFilter implements Filter {
         processRequest(spnegoRequest, response, chain);
     }
 
+    /**
+     * Passes the authenticated request down the filter chain.
+     *
+     * <p>
+     * Subclasses may override this method to perform additional processing
+     * after authentication has completed.
+     * </p>
+     *
+     * @param request the authenticated servlet request
+     * @param response the servlet response
+     * @param chain the filter chain
+     * @throws IOException if an I/O error occurs
+     * @throws ServletException if a servlet error occurs
+     */
     protected void processRequest(final SpnegoHttpServletRequest request, final ServletResponse response, final FilterChain chain)
             throws IOException, ServletException {
         chain.doFilter(request, response);

--- a/src/main/java/org/codelibs/spnego/SpnegoHttpServletResponse.java
+++ b/src/main/java/org/codelibs/spnego/SpnegoHttpServletResponse.java
@@ -41,8 +41,9 @@ public final class SpnegoHttpServletResponse extends HttpServletResponseWrapper 
     private boolean statusSet = false;
 
     /**
-     * 
-     * @param response
+     * Wraps the given HTTP servlet response.
+     *
+     * @param response the HTTP servlet response to wrap
      */
     public SpnegoHttpServletResponse(final HttpServletResponse response) {
         super(response);
@@ -69,8 +70,8 @@ public final class SpnegoHttpServletResponse extends HttpServletResponseWrapper 
      * 
      * @param status http status code
      * @param immediate set to true to set content len to zero and flush
-     * @throws IOException 
-     * 
+     * @throws IOException if an I/O error occurs while flushing the buffer
+     *
      * @see #setStatus(int)
      */
     public void setStatus(final int status, final boolean immediate) throws IOException {

--- a/src/main/java/org/codelibs/spnego/SpnegoHttpURLConnection.java
+++ b/src/main/java/org/codelibs/spnego/SpnegoHttpURLConnection.java
@@ -116,10 +116,10 @@ import org.ietf.jgss.GSSException;
  * </p>
  * 
  * <p>
- * Finally, the {@link SpnegoSOAPConnection} class is another example of a class 
+ * Finally, the {@link SpnegoSOAPConnection} class is another example of a class
  * that uses this class.
- * <p>
- * 
+ * </p>
+ *
  * @author Darwin V. Felix
  * 
  */
@@ -242,8 +242,8 @@ public final class SpnegoHttpURLConnection {
      * file being specified by "java.security.auth.login.config" or 
      * where LoginContext relies on tgtsessionkey.
      * 
-     * @param loginModuleName 
-     * @throws LoginException 
+     * @param loginModuleName module name defined in login.conf
+     * @throws LoginException if the login fails
      */
     public SpnegoHttpURLConnection(final String loginModuleName)
         throws LoginException {
@@ -281,10 +281,10 @@ public final class SpnegoHttpURLConnection {
      * file. However, the "java.security.auth.login.config" property must still
      * be set prior to instantiating this object.
      * 
-     * @param loginModuleName 
-     * @param username 
-     * @param password 
-     * @throws LoginException 
+     * @param loginModuleName module name defined in login.conf
+     * @param username the username to authenticate as
+     * @param password the password for the user
+     * @throws LoginException if the login fails
      */
     public SpnegoHttpURLConnection(final String loginModuleName,
         final String username, final String password) throws LoginException {
@@ -327,12 +327,12 @@ public final class SpnegoHttpURLConnection {
      * for the second argument.
      * </p>
      * 
-     * @param url 
+     * @param url the URL to connect to
      * @return an HttpURLConnection object
-     * @throws GSSException 
-     * @throws PrivilegedActionException 
-     * @throws IOException 
-     * 
+     * @throws GSSException if a GSS-API error occurs
+     * @throws PrivilegedActionException if a privileged action fails
+     * @throws IOException if an I/O error occurs
+     *
      * @see java.net.URLConnection#connect()
      */
     public HttpURLConnection connect(final URL url)
@@ -345,13 +345,13 @@ public final class SpnegoHttpURLConnection {
      * Opens a communications link to the resource referenced by 
      * this URL, if such a connection has not already been established.
      * 
-     * @param url 
+     * @param url the URL to connect to
      * @param dooutput optional message/payload to send to server
      * @return an HttpURLConnection object
-     * @throws GSSException 
-     * @throws PrivilegedActionException 
-     * @throws IOException 
-     * 
+     * @throws GSSException if a GSS-API error occurs
+     * @throws PrivilegedActionException if a privileged action fails
+     * @throws IOException if an I/O error occurs
+     *
      * @see java.net.URLConnection#connect()
      */
     public HttpURLConnection connect(final URL url, final ByteArrayOutputStream dooutput)
@@ -596,8 +596,8 @@ public final class SpnegoHttpURLConnection {
      * Returns an error stream that reads from this open connection.
      * 
      * @return error stream that reads from this open connection
-     * @throws IOException 
-     * 
+     * @throws IOException if an I/O error occurs
+     *
      * @see java.net.HttpURLConnection#getErrorStream()
      */
     public InputStream getErrorStream() throws IOException {
@@ -608,8 +608,8 @@ public final class SpnegoHttpURLConnection {
 
     /**
      * Get header value at specified index.
-     * 
-     * @param index
+     *
+     * @param index the index of the header value
      * @return header value at specified index
      */
     public String getHeaderField(final int index) {
@@ -633,8 +633,8 @@ public final class SpnegoHttpURLConnection {
     
     /**
      * Get header field key at specified index.
-     * 
-     * @param index
+     *
+     * @param index the index of the header field key
      * @return header field key at specified index
      */
     public String getHeaderFieldKey(final int index) {
@@ -644,6 +644,8 @@ public final class SpnegoHttpURLConnection {
     }
 
     /**
+     * Returns whether this connection automatically follows redirects.
+     *
      * @return true if it should follow redirects
      * @see java.net.HttpURLConnection#getInstanceFollowRedirects()
      */
@@ -652,7 +654,9 @@ public final class SpnegoHttpURLConnection {
     }
 
     /**
-     * @param followRedirects 
+     * Sets whether this connection automatically follows redirects.
+     *
+     * @param followRedirects true to follow redirects automatically
      * @see java.net.HttpURLConnection#setInstanceFollowRedirects(boolean)
      */
     public void setInstanceFollowRedirects(final boolean followRedirects) {
@@ -665,8 +669,8 @@ public final class SpnegoHttpURLConnection {
      * Returns an input stream that reads from this open connection.
      * 
      * @return input stream that reads from this open connection
-     * @throws IOException 
-     * 
+     * @throws IOException if an I/O error occurs
+     *
      * @see java.net.HttpURLConnection#getInputStream()
      */
     public InputStream getInputStream() throws IOException {
@@ -679,8 +683,8 @@ public final class SpnegoHttpURLConnection {
      * Returns an output stream that writes to this open connection.
      * 
      * @return output stream that writes to this connections
-     * @throws IOException
-     * 
+     * @throws IOException if an I/O error occurs
+     *
      * @see java.net.HttpURLConnection#getOutputStream()
      */
     public OutputStream getOutputStream() throws IOException {
@@ -693,8 +697,8 @@ public final class SpnegoHttpURLConnection {
      * Returns HTTP Status code.
      * 
      * @return HTTP Status Code
-     * @throws IOException 
-     * 
+     * @throws IOException if an I/O error occurs
+     *
      * @see java.net.HttpURLConnection#getResponseCode()
      */
     public int getResponseCode() throws IOException {
@@ -707,8 +711,8 @@ public final class SpnegoHttpURLConnection {
      * Returns HTTP Status message.
      * 
      * @return HTTP Status Message
-     * @throws IOException 
-     * 
+     * @throws IOException if an I/O error occurs
+     *
      * @see java.net.HttpURLConnection#getResponseMessage()
      */
     public String getResponseMessage() throws IOException {
@@ -809,9 +813,9 @@ public final class SpnegoHttpURLConnection {
     
     /**
      * May override the default GET method.
-     * 
-     * @param method 
-     * 
+     *
+     * @param method the HTTP request method to use
+     *
      * @see java.net.HttpURLConnection#setRequestMethod(String)
      */
     public void setRequestMethod(final String method) {

--- a/src/main/java/org/codelibs/spnego/SpnegoProvider.java
+++ b/src/main/java/org/codelibs/spnego/SpnegoProvider.java
@@ -159,7 +159,7 @@ public final class SpnegoProvider {
      * 
      * @param subject the person to be authenticated
      * @return GSSCredential to be used for creating a security context.
-     * @throws PrivilegedActionException
+     * @throws PrivilegedActionException if a privileged action fails
      */
     public static GSSCredential getClientCredential(final Subject subject)
         throws PrivilegedActionException {
@@ -185,8 +185,8 @@ public final class SpnegoProvider {
      * 
      * @param creds credentials of the person to be authenticated
      * @param url HTTP address of server (used for constructing a {@link GSSName}).
-     * @return GSSContext 
-     * @throws GSSException
+     * @return GSSContext
+     * @throws GSSException if a GSS-API error occurs
      */
     public static GSSContext getGSSContext(final GSSCredential creds, final URL url) 
         throws GSSException {

--- a/src/main/java/org/codelibs/spnego/SpnegoSOAPConnection.java
+++ b/src/main/java/org/codelibs/spnego/SpnegoSOAPConnection.java
@@ -149,8 +149,8 @@ public class SpnegoSOAPConnection extends SOAPConnection {
      * file being specified by "java.security.auth.login.config" or 
      * where LoginContext relies on tgtsessionkey.
      * 
-     * @param loginModuleName 
-     * @throws LoginException 
+     * @param loginModuleName module name defined in login.conf
+     * @throws LoginException if the login fails
      */
     public SpnegoSOAPConnection(final String loginModuleName) throws LoginException {
         super();
@@ -199,8 +199,8 @@ public class SpnegoSOAPConnection extends SOAPConnection {
      * 
      * @param creds credentials to use
      * @param dispose true if GSSCredential should be diposed after use
-     * @param confidential
-     * @param integrity
+     * @param confidential true to require message confidentiality
+     * @param integrity true to require mutual message integrity
      */
     public SpnegoSOAPConnection(final GSSCredential creds, final boolean dispose
         , final boolean confidential, final boolean integrity) {
@@ -221,10 +221,10 @@ public class SpnegoSOAPConnection extends SOAPConnection {
      * file. However, the "java.security.auth.login.config" property must still
      * be set prior to instantiating this object.
      * 
-     * @param loginModuleName 
-     * @param username 
-     * @param password 
-     * @throws LoginException 
+     * @param loginModuleName module name defined in login.conf
+     * @param username the username to authenticate as
+     * @param password the password for the user
+     * @throws LoginException if the login fails
      */
     public SpnegoSOAPConnection(final String loginModuleName,
         final String username, final String password) throws LoginException {

--- a/src/main/java/org/codelibs/spnego/UserAccessControl.java
+++ b/src/main/java/org/codelibs/spnego/UserAccessControl.java
@@ -491,7 +491,8 @@ public interface UserAccessControl {
     
     /**
      * Returns the user's info object for the given user.
-     * 
+     *
+     * @param username the username to look up
      * @return the user's info object for the given user
      */
     UserInfo getUserInfo(final String username);
@@ -505,10 +506,12 @@ public interface UserAccessControl {
      * </p>
      * 
      * <p>
-     * If this method has been called and a reference to the instance is 
-     * maintained, this method should not be called again unless the destroy 
+     * If this method has been called and a reference to the instance is
+     * maintained, this method should not be called again unless the destroy
      * method is called first.
      * </p>
+     *
+     * @param props the properties used to initialize this instance
      */
-    void init(final Properties props); 
+    void init(final Properties props);
 }


### PR DESCRIPTION
## Summary
Improves the Javadoc documentation across the core SPNEGO classes. Many public constructors, methods, and tags were previously empty or malformed; this fills them in with meaningful descriptions so the generated API docs are useful and so Javadoc builds emit fewer warnings.

## Changes Made
- Filled in empty `@param`, `@return`, and `@throws` tags with descriptive text in `SpnegoAuthenticator`, `SpnegoHttpURLConnection`, `SpnegoSOAPConnection`, `SpnegoProvider`, `SpnegoHttpServletResponse`, and `UserAccessControl`.
- Added missing class-level Javadoc to `Base64`.
- Added an explicit default constructor with Javadoc to `SpnegoHttpFilter` and documented the `processRequest` hook method.
- Documented `getServerRealm()`, `getInstanceFollowRedirects()`, and `setInstanceFollowRedirects()`.
- Cleaned up malformed Javadoc blocks (unclosed `<p>` tag, trailing whitespace on tag lines).

## Testing
Documentation-only change; no behavioral code was modified. Existing test suite (`mvn test`) continues to cover the affected classes.

## Breaking Changes
None. The added no-arg constructor in `SpnegoHttpFilter` preserves the previously implicit default constructor.

## Additional Notes
All edits are confined to comments and one explicit (previously implicit) constructor, so the public API surface is unchanged.